### PR TITLE
Allow scroll to use post, since scroll_id can be too long

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ except IOError:
 
 
 setuptools.setup(name='tornado_elasticsearch',
-                 version='0.4.0',
+                 version='0.4.0.quid1',
                  description=desc,
                  long_description=readme,
                  author='Gavin M. Roy',


### PR DESCRIPTION
The scroll and clear_scroll routes currently use a GET route. This leads to an HTTP error code 414(URI too long) when many shards are present, because the length of scroll_id increases as shard size increases and this scroll_id is present in the URL when GET is used.

However, both scroll and clear_scroll support POST on the elasticsearch side. This PR changes both routes to use POST internally, which will move the scroll_id from the URL to the body of the request, thus removing the problem
