### PR TITLE
fixed typo in exists return-raise; added get_alias

### DIFF
--- a/tornado_elasticsearch.py
+++ b/tornado_elasticsearch.py
@@ -387,6 +387,30 @@ class AsyncElasticsearch(Elasticsearch):
 
     @gen.coroutine
     @query_params('allow_no_indices', 'expand_wildcards', 'ignore_unavailable',
+        'local')
+    def exists_alias(self, index=None, name=None, params=None):
+        """
+        Return a boolean indicating whether given alias exists.
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html>`_
+        :arg index: A comma-separated list of index names to filter aliases
+        :arg name: A comma-separated list of alias names to return
+        :arg allow_no_indices: Whether to ignore if a wildcard indices
+            expression resolves into no concrete indices. (This includes `_all`
+            string or when no indices have been specified)
+        :arg expand_wildcards: Whether to expand wildcard expression to concrete
+            indices that are open, closed or both., default ['open', 'closed'],
+            valid choices are: 'open', 'closed', 'none', 'all'
+        :arg ignore_unavailable: Whether specified concrete indices should be
+            ignored when unavailable (missing or closed)
+        :arg local: Return local information, do not retrieve the state from
+            master node (default: false)
+        """
+        _, result = yield self.transport.perform_request('HEAD', _make_path(index, '_alias',
+                name), params=params)
+        raise gen.Return(result)
+
+    @gen.coroutine
+    @query_params('allow_no_indices', 'expand_wildcards', 'ignore_unavailable',
                   'local')
     def get_alias(self, index=None, name=None, params=None):
         """

--- a/tornado_elasticsearch.py
+++ b/tornado_elasticsearch.py
@@ -348,7 +348,7 @@ class AsyncElasticsearch(Elasticsearch):
                                            _make_path(index, doc_type, id),
                                            params=params)
         except NotFoundError:
-            return gen.Return(False)
+            raise gen.Return(False)
         raise gen.Return(True)
 
     @gen.coroutine
@@ -384,6 +384,30 @@ class AsyncElasticsearch(Elasticsearch):
                                                                   doc_type, id),
                                                        params=params)
         raise gen.Return(data)
+
+    @gen.coroutine
+    @query_params('allow_no_indices', 'expand_wildcards', 'ignore_unavailable',
+                  'local')
+    def get_alias(self, index=None, name=None, params=None):
+        """
+        Retrieve a specified alias.
+        `<http://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html>`_
+        :arg index: A comma-separated list of index names to filter aliases
+        :arg name: A comma-separated list of alias names to return
+        :arg allow_no_indices: Whether to ignore if a wildcard indices
+            expression resolves into no concrete indices. (This includes `_all`
+            string or when no indices have been specified)
+        :arg expand_wildcards: Whether to expand wildcard expression to
+            concrete indices that are open, closed or both., default 'all',
+            valid choices are: 'open', 'closed', 'none', 'all'
+        :arg ignore_unavailable: Whether specified concrete indices should be
+            ignored when unavailable (missing or closed)
+        :arg local: Return local information, do not retrieve the state from
+            master node (default: false)
+        """
+        _, result = yield self.transport.perform_request(
+            'GET', _make_path(index, '_alias', name), params=params)
+        raise gen.Return(result)
 
     @gen.coroutine
     @query_params('_source_exclude', '_source_include', 'parent', 'preference',


### PR DESCRIPTION
In case an index was not found, `exists` was returning False instead of raising it. Functionality for [`get_alias`](https://github.com/elastic/elasticsearch-py/blob/master/elasticsearch/client/indices.py#L381) did not exist prior.
