### PR TITLE
[#11] Added method for cluster health API call.

### DIFF
--- a/tornado_elasticsearch.py
+++ b/tornado_elasticsearch.py
@@ -262,6 +262,22 @@ class AsyncElasticsearch(Elasticsearch):
         raise gen.Return(data)
 
     @gen.coroutine
+    def health(self, params=None):
+        """Coroutine. Queries cluster Health API.
+
+        Returns a 2-tuple, where first element is request status, and second
+        element is a dictionary with response data.
+
+        :param params: dictionary of query parameters, will be handed over to
+            the underlying :class:`~torando_elasticsearch.AsyncHTTPConnection`
+            class for serialization
+
+        """
+        status, data = yield self.transport.perform_request(
+            "GET", "/_cluster/health", params=params)
+        raise gen.Return((status, data))
+
+    @gen.coroutine
     @query_params('consistency', 'id', 'parent', 'percolate', 'refresh',
                   'replication', 'routing', 'timeout', 'timestamp', 'ttl',
                   'version', 'version_type')


### PR DESCRIPTION
Fix for [#11](https://github.com/gmr/tornado-elasticsearch/issues/11)
 - Added method to call `_cluster/health` to use instead of `info`method, which is no longer supported in newer Elasticsearch server versions.