### PR TITLE
bug fixes for handling of error responses and empty response body

### DIFF
--- a/tornado_elasticsearch.py
+++ b/tornado_elasticsearch.py
@@ -88,7 +88,7 @@ class AsyncHttpConnection(Connection):
             if not (200 <= response.code < 300) and \
                     response.code not in ignore:
                 LOGGER.debug('Error: %r', raw_data)
-                self.log_request_fail(method, url, body, duration,
+                self.log_request_fail(method, request_uri, url, body, duration,
                                       response.code)
                 error = exceptions.HTTP_EXCEPTIONS.get(response.code,
                                                        TransportError)

--- a/tornado_elasticsearch.py
+++ b/tornado_elasticsearch.py
@@ -226,7 +226,7 @@ class AsyncTransport(Transport):
                 self.connection_pool.mark_live(connection)
                 response = self.deserializer.loads(data,
                                                    headers.get('content-type')
-                                                   if data else None)
+                                                   ) if data else None
                 raise gen.Return((status, response))
 
 


### PR DESCRIPTION
I noticed that when the request results in a 404 (such as an index exists request) tornado_elasticsearch is missing the full_url parameter in it's log_request_fail() call which results in an unexpected exception as log_request_fail() ends up trying to call decode() on the duration float rather than the body string.

I also noticed that a bracket is misplaced in AsyncTransport.perform_request() which results in self.deserializer.loads() being called without a content-type when data is falsy. If data is an empty string this results in a SerializationError when the JSON library tries to decode the empty string. This was preventing any HEAD requests from completing successfully.