### PR TITLE
Restore compatibility with elasticsearch 2.x error logging

### DIFF
--- a/tornado_elasticsearch.py
+++ b/tornado_elasticsearch.py
@@ -19,6 +19,7 @@ on how to use the API beyond the introduction for how to use with Tornado::
             self.finish(info)
 
 """
+from elasticsearch import VERSION as ELASTICSEARCH_VERSION
 from elasticsearch.connection.base import Connection
 from elasticsearch import exceptions
 from elasticsearch.client import Elasticsearch
@@ -88,8 +89,12 @@ class AsyncHttpConnection(Connection):
             if not (200 <= response.code < 300) and \
                     response.code not in ignore:
                 LOGGER.debug('Error: %r', raw_data)
-                self.log_request_fail(method, request_uri, url, body, duration,
-                                      response.code)
+                if ELASTICSEARCH_VERSION < (5, 0, 0):
+                    self.log_request_fail(method, request_uri, body,
+                                          duration, response.code)
+                else:
+                    self.log_request_fail(method, request_uri, url, body,
+                                          duration, response.code)
                 error = exceptions.HTTP_EXCEPTIONS.get(response.code,
                                                        TransportError)
                 raise error(response.code, raw_data)


### PR DESCRIPTION
Between elasticsearch-py [2.x](https://github.com/elastic/elasticsearch-py/blob/2.4.1/elasticsearch/connection/base.py#L81) and [5.x](https://github.com/elastic/elasticsearch-py/blob/5.2.0/elasticsearch/connection/base.py#L87), the signature of the `log_request_fail` method on the `Connection` object changed.  An additional `path` parameter was added.  As a result of this, there is an unexpected exception raised by tornado_elasticsearch during the handling an HTTP error.  This commit adds a check to determine the version of elasticsearch and uses the appropriate call signature.