### PR TITLE
_delete_by_query using appropriate endpoint and operation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 tornado>4
-elasticsearch>=2.3
+elasticsearch>=5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 tornado>4
-elasticsearch>=5.0
+elasticsearch>=2.3

--- a/tornado_elasticsearch.py
+++ b/tornado_elasticsearch.py
@@ -834,10 +834,10 @@ class AsyncElasticsearch(Elasticsearch):
         :arg q: Query in the Lucene query string syntax
         :arg timeout: Explicit operation timeout
         """
-        _, data = yield self.transport.perform_request('DELETE',
+        _, data = yield self.transport.perform_request('POST',
                                                        _make_path(index,
                                                                   doc_type,
-                                                                  '_query'),
+                                                                  '_delete_by_query'),
                                                        params=params, body=body)
         raise gen.Return(data)
 

--- a/tornado_elasticsearch.py
+++ b/tornado_elasticsearch.py
@@ -21,6 +21,7 @@ on how to use the API beyond the introduction for how to use with Tornado::
 """
 from elasticsearch.connection.base import Connection
 from elasticsearch import exceptions
+from elasticsearch import VERSION as ELASTICSEARCH_VERSION
 from elasticsearch.client import Elasticsearch
 from elasticsearch.transport import Transport, TransportError
 from elasticsearch.client.utils import query_params, _make_path
@@ -834,10 +835,17 @@ class AsyncElasticsearch(Elasticsearch):
         :arg q: Query in the Lucene query string syntax
         :arg timeout: Explicit operation timeout
         """
-        _, data = yield self.transport.perform_request('POST',
+        if ELASTICSEARCH_VERSION[0] >= 5:
+            op = 'POST'
+            endpoint = '_delete_by_query'
+        else:
+            op = 'DELETE'
+            endpoint = '_query'
+
+        _, data = yield self.transport.perform_request(op,
                                                        _make_path(index,
                                                                   doc_type,
-                                                                  '_delete_by_query'),
+                                                                  endpoint),
                                                        params=params, body=body)
         raise gen.Return(data)
 

--- a/tornado_elasticsearch.py
+++ b/tornado_elasticsearch.py
@@ -57,15 +57,14 @@ class AsyncHttpConnection(Connection):
     _auth_user = None
     _auth_password = None
     _user_agent = 'tornado_elasticsearch %s/Tornado %s' % (__version__, version)
-    ssl_transport_schema = 'https'
 
     def __init__(self, host='localhost', port=9200, http_auth=None,
                  use_ssl=False, request_timeout=None, max_clients=10, **kwargs):
         super(AsyncHttpConnection, self).__init__(host=host, port=port,
                                                   **kwargs)
         self._assign_auth_values(http_auth)
-        self.base_url = '%s://%s:%s%s' % (self.ssl_transport_schema if use_ssl
-                                          else self.transport_schema,
+        self.base_url = '%s://%s:%s%s' % ('https' if use_ssl
+                                          else 'http',
                                           host, port, self.url_prefix)
         httpclient.AsyncHTTPClient.configure(None, max_clients=max_clients)
         self._client = httpclient.AsyncHTTPClient()


### PR DESCRIPTION
ES 5+ has gone back to using a POST to _delete_by_query rather than a DELETE to _query